### PR TITLE
AuditableRepository can select identity field

### DIFF
--- a/Yarn/Extensions/RepositoryExtensions.cs
+++ b/Yarn/Extensions/RepositoryExtensions.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Security.Claims;
 using System.Security.Principal;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Yarn.Adapters;
 
 namespace Yarn.Extensions
@@ -48,6 +44,11 @@ namespace Yarn.Extensions
         public static IRepository WithAudit(this IRepository repository, IPrincipal principal = null)
         {
             return new AuditableRepository(repository, principal ?? Thread.CurrentPrincipal);
+        }
+
+        public static IRepository WithAudit(this IRepository repository, Func<string> getOwnerIdentity)
+        {
+            return new AuditableRepository(repository, getOwnerIdentity);
         }
 
         public static IRepository WithMultiTenancy(this IRepository repository, ITenant tenant)

--- a/Yarn/IAuditable.cs
+++ b/Yarn/IAuditable.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Yarn
 {


### PR DESCRIPTION
Allow AuditableRepository to to be more flexible in which value get stored in CreatedBy and UpdatedBy, instead of forcing it to always use _principal.Identity.Name. This is useful in situations where the necessary auditable information may be some other unique identifier such as an SSO ID, email address, etc.