### PR TITLE
Enable auto-wiring behavior in IContainer

### DIFF
--- a/Yarn.StructureMap/IoC/StructureMap/StructureMapContainer.cs
+++ b/Yarn.StructureMap/IoC/StructureMap/StructureMapContainer.cs
@@ -1,9 +1,5 @@
-﻿using StructureMap;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
+using StructureMap;
 
 namespace Yarn.IoC.StructureMap
 {
@@ -50,7 +46,7 @@ namespace Yarn.IoC.StructureMap
 
         public void Register<TAbstract, TConcrete>(string instanceName = null)
             where TAbstract : class
-            where TConcrete : class, TAbstract, new()
+            where TConcrete : class, TAbstract
         {
             if (instanceName == null)
             {

--- a/Yarn/IoC/DefaultContainer.cs
+++ b/Yarn/IoC/DefaultContainer.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Yarn.IoC
 {
@@ -17,9 +14,9 @@ namespace Yarn.IoC
 
         public void Register<TAbstract, TConcrete>(string instanceName = null)
             where TAbstract : class
-            where TConcrete : class, TAbstract, new()
+            where TConcrete : class, TAbstract
         {
-            Func<TAbstract> createInstance = () => new TConcrete();
+            Func<TAbstract> createInstance = Activator.CreateInstance<TConcrete>;
             Register(createInstance, instanceName);
         }
 

--- a/Yarn/IoC/IContainer.cs
+++ b/Yarn/IoC/IContainer.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Yarn.IoC
 {
@@ -10,7 +6,7 @@ namespace Yarn.IoC
     {
         void Register<TAbstract, TConcrete>(string instanceName = null) 
             where TAbstract : class
-            where TConcrete : class, TAbstract, new();
+            where TConcrete : class, TAbstract;
 
         void Register<TAbstract, TConcrete>(TConcrete instance, string instanceName = null)
             where TAbstract : class


### PR DESCRIPTION
Remove new() constraint on IContainer.Register, which will allow IoC containers without this restraint (which is most modern IoCs, in some manner or another) to use auto-wiring behavior.

The DefaultContainer obviously doesn't support auto-wiring so we fall back to Activator.CreateInstance to attempt the creation of the type and throw exceptions where arguments are expected. The down side is that when using the DefaultContainer errors like this are run-time errors instead of compile-time errors. For all other IoC containers, this change enables an important feature so I suspect the trade-off is net positive.